### PR TITLE
Odoo: Update architecture field to include arm64

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -3,14 +3,14 @@ GitRepo: https://github.com/odoo/docker
 GitCommit: 61148a86eed7fb5452dc7705b479988e1f49f9a6
 
 Tags: 16.0, 16, latest
-Architectures: amd64
+Architectures: amd64,arm64
 Directory: 16.0
 
 Tags: 15.0, 15
-Architectures: amd64
+Architectures: amd64,arm64
 Directory: 15.0
 
 Tags: 14.0, 14
-Architectures: amd64
+Architectures: amd64,arm64
 Directory: 14.0
 


### PR DESCRIPTION
I believe this is just a matter of including this here as the container being used upstream is multi-arch supported one.